### PR TITLE
fix: not use deprecated options of ansible-lint-action

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,4 @@
+roles/common/handlers/main.yml no-changed-when
+roles/common/tasks/docker.yml yaml[octal-values]
+roles/common/tasks/ssh_config.yml yaml[octal-values]
+roles/common/tasks/zprezto.yml yaml[octal-values]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Lint Ansible Playbook
-      uses: ansible/ansible-lint-action@main
       with:
-        targets: "playbook"
-        args: ""
-    - name: Lint Ansible Roles
+        fetch-depth: 0
+
+    - name: Run ansible-lint
       uses: ansible/ansible-lint-action@main
-      with:
-        targets: "roles"
-        args: ""


### PR DESCRIPTION
https://github.com/ansible/ansible-lint-action