### PR TITLE
Change dock position from left to right

### DIFF
--- a/roles/common/tasks/osx.yml
+++ b/roles/common/tasks/osx.yml
@@ -5,11 +5,11 @@
     type: bool
     value: true
 
-- name: Place dock on the left side
+- name: Place dock on the right side
   community.general.osx_defaults:
     domain: com.apple.dock
     key: orientation
-    value: left
+    value: right
   notify: Restart Dock
 
 - name: Minimiza windows to application icons


### PR DESCRIPTION
## Summary
- Updated macOS dock orientation configuration to position the dock on the right side instead of the left

## Test plan
- [x] Run the Ansible playbook to apply the change
- [x] Verify the dock appears on the right side of the screen
- [x] Ensure the dock restart handler is triggered properly

🤖 Generated with [Claude Code](https://claude.ai/code)