### PR TITLE
Replace deprecated ansible_env with ansible_facts

### DIFF
--- a/roles/common/tasks/git_config.yml
+++ b/roles/common/tasks/git_config.yml
@@ -33,4 +33,4 @@
   community.general.git_config:
     name: ghq.root
     scope: global
-    value: "{{ ansible_env.HOME }}/src"
+    value: "{{ ansible_facts['env']['HOME'] }}/src"

--- a/roles/common/tasks/osx.yml
+++ b/roles/common/tasks/osx.yml
@@ -39,7 +39,7 @@
   community.general.osx_defaults:
     domain: com.apple.finder
     key: NewWindowTargetPath
-    value: "file://{{ ansible_env.HOME }}/"
+    value: "file://{{ ansible_facts['env']['HOME'] }}/"
   notify: Restart Finder
 
 - name: Show hidden files
@@ -90,5 +90,5 @@
   community.general.osx_defaults:
     domain: com.apple.screencapture
     key: location
-    value: "{{ ansible_env.HOME }}/Pictures"
+    value: "{{ ansible_facts['env']['HOME'] }}/Pictures"
   notify: Restart SystemUIServer

--- a/roles/common/tasks/ssh_config.yml
+++ b/roles/common/tasks/ssh_config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create ssh directories
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/{{ item }}"
+    path: "{{ ansible_facts['env']['HOME'] }}/{{ item }}"
     state: directory
     mode: "0700"
   with_items:
@@ -11,5 +11,5 @@
 - name: Update ~/.ssh/config
   ansible.builtin.copy:
     src: ssh/config
-    dest: "{{ ansible_env.HOME }}/.ssh/config"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.ssh/config"
     mode: "0600"

--- a/roles/common/tasks/zprezto.yml
+++ b/roles/common/tasks/zprezto.yml
@@ -2,25 +2,25 @@
 - name: Clone sorin-ionescu/prezto into ~/.zprezto
   ansible.builtin.git:
     repo: 'https://github.com/sorin-ionescu/prezto.git'
-    dest: "{{ ansible_env.HOME }}/.zprezto"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.zprezto"
     force: true
 
 - name: Customize zprezto autosuggestions
   ansible.builtin.lineinfile:
-    path: "{{ ansible_env.HOME }}/.zprezto/runcoms/zpreztorc"
+    path: "{{ ansible_facts['env']['HOME'] }}/.zprezto/runcoms/zpreztorc"
     line: "  'autosuggestions'  \\\n  'syntax-highlighting' \\"
     insertafter: "^zstyle ':prezto:load' pmodule"
 
 - name: Customize zprezto theme
   ansible.builtin.lineinfile:
-    path: "{{ ansible_env.HOME }}/.zprezto/runcoms/zpreztorc"
+    path: "{{ ansible_facts['env']['HOME'] }}/.zprezto/runcoms/zpreztorc"
     regexp: "^zstyle ':prezto:module:prompt' theme "
     line: "zstyle ':prezto:module:prompt' theme 'pure'"
 
 - name: Create symlinks related to zsh
   ansible.builtin.file:
-    src: "{{ ansible_env.HOME }}/.zprezto/runcoms/{{ item }}"
-    dest: "{{ ansible_env.HOME }}/.{{ item }}"
+    src: "{{ ansible_facts['env']['HOME'] }}/.zprezto/runcoms/{{ item }}"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.{{ item }}"
     state: link
   with_items:
     - zlogin
@@ -32,6 +32,6 @@
 - name: Update ~/.zshrc
   ansible.builtin.copy:
     src: zshrc
-    dest: "{{ ansible_env.HOME }}/.zshrc"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.zshrc"
     mode: "0644"
   notify: Suggest reloading zsh configuration


### PR DESCRIPTION
## Summary
- `ansible_env.HOME`を`ansible_facts["env"]["HOME"]`に置き換え
- Ansible 2.24で削除予定の`INJECT_FACTS_AS_VARS`非推奨警告を解消

## Changes
- `roles/common/tasks/osx.yml`
- `roles/common/tasks/git_config.yml`
- `roles/common/tasks/ssh_config.yml`
- `roles/common/tasks/zprezto.yml`

## Test plan
- [x] `uv run ansible-playbook -i hosts.yml playbooks/my-mac.yml --ask-become-pass`で警告が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)