### PR TITLE
Add nix-darwin configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .venv/
+result

--- a/README.md
+++ b/README.md
@@ -2,6 +2,34 @@
 
 Mac OS X configuration management using Ansible
 
+## nix-darwin
+
+This branch contains an initial nix-darwin + Home Manager configuration.
+
+### prerequisite
+
+Install Nix first. nix-darwin currently recommends a flake-based setup.
+
+### bootstrap
+
+```bash
+$ nix flake lock
+$ sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake .#uranus
+```
+
+### apply changes
+
+```bash
+$ sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#uranus
+```
+
+### update inputs
+
+```bash
+$ nix flake update
+$ sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#uranus
+```
+
 ## prerequisite
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,71 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779592288,
+        "narHash": "sha256-pVZwRFVFdHS3D3G07MiZQcSPENnv1xlYCJtfabkqd3Q=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "23703a32ef3d7803a2f1bb9909a3f46fc5185e37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "ref": "master",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779536132,
+        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "macOS configuration for naoki";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    nix-darwin.url = "github:nix-darwin/nix-darwin/master";
+    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+
+    home-manager.url = "github:nix-community/home-manager/master";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs =
+    inputs@{
+      self,
+      nix-darwin,
+      home-manager,
+      nixpkgs,
+    }:
+    let
+      username = "naoki";
+      hostname = "uranus";
+      system = "aarch64-darwin";
+    in
+    {
+      darwinConfigurations.${hostname} = nix-darwin.lib.darwinSystem {
+        inherit system;
+        specialArgs = {
+          inherit inputs username hostname;
+        };
+        modules = [
+          ./nix/darwin.nix
+          home-manager.darwinModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.backupFileExtension = "before-home-manager";
+            home-manager.extraSpecialArgs = {
+              inherit inputs username hostname;
+            };
+            home-manager.users.${username} = import ./nix/home.nix;
+          }
+        ];
+      };
+
+      formatter.${system} = nixpkgs.legacyPackages.${system}.nixfmt-rfc-style;
+    };
+}

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -1,0 +1,67 @@
+{
+  pkgs,
+  username,
+  ...
+}:
+
+{
+  nix.settings.experimental-features = [
+    "nix-command"
+    "flakes"
+  ];
+
+  nixpkgs.hostPlatform = "aarch64-darwin";
+
+  system.primaryUser = username;
+  system.stateVersion = 7;
+
+  users.users.${username}.home = "/Users/${username}";
+
+  programs.zsh.enable = true;
+
+  environment.systemPackages = with pkgs; [
+    curl
+    fzf
+    gh
+    ghq
+    git
+    gnused
+    gnutar
+    jq
+    mise
+    starship
+    tree
+    wget
+    yq
+  ];
+
+  system.defaults = {
+    dock = {
+      orientation = "right";
+      minimize-to-application = true;
+      show-recents = false;
+    };
+
+    finder = {
+      AppleShowAllExtensions = true;
+      NewWindowTarget = "Home";
+      AppleShowAllFiles = true;
+      FXPreferredViewStyle = "clmv";
+    };
+
+    screencapture = {
+      type = "png";
+      disable-shadow = true;
+      location = "/Users/${username}/Pictures";
+    };
+
+    CustomUserPreferences = {
+      "com.apple.desktopservices" = {
+        DSDontWriteNetworkStores = true;
+      };
+      "com.apple.screencapture" = {
+        name = "ss_";
+      };
+    };
+  };
+}

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  username,
+  ...
+}:
+
+{
+  home.username = username;
+  home.homeDirectory = "/Users/${username}";
+  home.stateVersion = "25.11";
+
+  programs.home-manager.enable = true;
+
+  programs.git = {
+    enable = true;
+    settings = {
+      user = {
+        name = "Naoki Oketani";
+        email = "okepy.naoki@gmail.com";
+      };
+      color.ui = true;
+      core.editor = "vim";
+      pull.ff = "only";
+      ghq.root = "/Users/${username}/src";
+    };
+  };
+
+  home.file.".zshrc".source = ./zshrc;
+  home.file.".ssh/config".source = ../roles/common/files/ssh/config;
+
+  home.activation.createSshDirs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD mkdir -p "$HOME/.ssh/github"
+    $DRY_RUN_CMD chmod 700 "$HOME/.ssh" "$HOME/.ssh/github"
+    $DRY_RUN_CMD chmod 600 "$HOME/.ssh/config" 2>/dev/null || true
+  '';
+}

--- a/nix/zshrc
+++ b/nix/zshrc
@@ -1,0 +1,40 @@
+# Use emacs keybindings (Ctrl-A, Ctrl-E, etc.)
+bindkey -e
+
+autoload -Uz compinit && compinit
+autoload -U +X bashcompinit && bashcompinit
+
+export EDITOR=vim
+
+export GOPATH="$HOME/go"
+if [ -d "$HOME/go/bin" ]; then
+  export PATH="$HOME/go/bin:$PATH"
+fi
+
+if [ -d "$HOME/.local/bin" ]; then
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+alias g='cd $(ghq root)/$(ghq list | fzf)'
+alias k=kubectl
+
+if command -v kubectl >/dev/null 2>&1; then
+  source <(kubectl completion zsh)
+  compdef __start_kubectl k
+fi
+
+# The next line makes PATH unique.
+typeset -U path PATH
+
+# fzf key bindings (Ctrl-R for history search) and completion
+if command -v fzf >/dev/null 2>&1; then
+  source <(fzf --zsh)
+fi
+
+if command -v mise >/dev/null 2>&1; then
+  eval "$(mise activate zsh)"
+fi
+
+if command -v starship >/dev/null 2>&1; then
+  eval "$(starship init zsh)"
+fi


### PR DESCRIPTION
## Summary

- Add a repository-managed nix-darwin flake for the `uranus` host
- Add Home Manager configuration for zsh, git, and ssh
- Manage existing CLI packages and macOS defaults with Nix/nix-darwin
- Document bootstrap, apply, and update commands
- Ignore the `result` symlink generated by `darwin-rebuild build`

## Validation

- `nix flake lock`
- `darwin-rebuild build --flake .#uranus`
- `sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#uranus`

Closes #29
Part of #26
