### PR TITLE
Use 1Password SSH agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $ sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#uranus
 | macOS defaults | `system.defaults` in `nix/darwin.nix` | Dock, Finder, desktop services, and screenshot defaults are managed by nix-darwin. |
 | zsh | `home.file.".zshrc"` in `nix/home.nix` | The zshrc content lives in `nix/zshrc`. |
 | Git | `programs.git.settings` in `nix/home.nix` | Global Git configuration is managed by Home Manager. |
-| SSH | `home.file.".ssh/config"` and `home.activation.createSshDirs` in `nix/home.nix` | SSH config lives in `nix/ssh_config`, and directories are created during activation. |
+| SSH | `home.file.".ssh/config"` and `home.activation.createSshDirs` in `nix/home.nix` | SSH config lives in `nix/ssh_config` and uses the 1Password SSH agent. |
 | Docker completion | `docker completion zsh` in `nix/zshrc` | Docker completion is loaded dynamically when the `docker` command is available. |
 
 This repository used to manage macOS with Ansible and Homebrew. The Ansible implementation has been removed after reaching parity with the Nix configuration.

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -29,8 +29,8 @@
   home.file.".ssh/config".source = ./ssh_config;
 
   home.activation.createSshDirs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    $DRY_RUN_CMD mkdir -p "$HOME/.ssh/github"
-    $DRY_RUN_CMD chmod 700 "$HOME/.ssh" "$HOME/.ssh/github"
+    $DRY_RUN_CMD mkdir -p "$HOME/.ssh"
+    $DRY_RUN_CMD chmod 700 "$HOME/.ssh"
     $DRY_RUN_CMD chmod 600 "$HOME/.ssh/config" 2>/dev/null || true
   '';
 }

--- a/nix/ssh_config
+++ b/nix/ssh_config
@@ -1,9 +1,2 @@
 Host *
-    ForwardAgent yes
-
-Host github.com
-    HostName github.com
-    IdentityFile ~/.ssh/github/id_ed25519
-    TCPKeepAlive yes
-    IdentitiesOnly yes
-    User git
+    IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"


### PR DESCRIPTION
## Summary

- Replace the GitHub-specific SSH key config with the 1Password SSH agent `IdentityAgent` setting
- Remove `ForwardAgent yes` and the `~/.ssh/github/id_ed25519` dependency
- Stop creating `~/.ssh/github` during Home Manager activation
- Update README to mention the 1Password SSH agent

## Validation

- `ssh -F nix/ssh_config -G github.com` shows the 1Password `IdentityAgent` and `forwardagent no`
- `darwin-rebuild build --flake .#uranus`

## Follow-up after merge

Apply the configuration, then remove the old key directory:

```bash
sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#uranus
rm -rf ~/.ssh/github
```

References:

- https://www.1password.dev/ssh/manage-keys
- https://www.1password.dev/ssh/get-started
