### PR TITLE
Replace mise-managed Node with Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ $ sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#uranus
 | Area | Location | Notes |
 | --- | --- | --- |
 | CLI packages | `environment.systemPackages` in `nix/darwin.nix` | Command-line tools are installed from nixpkgs. |
+| Node.js | `nodejs_24` in `nix/darwin.nix` | Node.js is installed from nixpkgs instead of mise. |
 | macOS defaults | `system.defaults` in `nix/darwin.nix` | Dock, Finder, desktop services, and screenshot defaults are managed by nix-darwin. |
 | zsh | `home.file.".zshrc"` in `nix/home.nix` | The zshrc content lives in `nix/zshrc`. |
 | Git | `programs.git.settings` in `nix/home.nix` | Global Git configuration is managed by Home Manager. |
@@ -74,3 +75,13 @@ $ sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#uranus
 | Docker completion | `docker completion zsh` in `nix/zshrc` | Docker completion is loaded dynamically when the `docker` command is available. |
 
 This repository used to manage macOS with Ansible and Homebrew. The Ansible implementation has been removed after reaching parity with the Nix configuration.
+
+### manual cleanup
+
+After applying the Nix configuration, remove old mise state if it is no longer needed.
+
+```bash
+$ rm -rf ~/.config/mise ~/.local/share/mise
+```
+
+Claude and Codex CLI installation methods are tracked separately because they were originally installed outside this repository.

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -28,7 +28,7 @@
     gnused
     gnutar
     jq
-    mise
+    nodejs_24
     starship
     tree
     wget

--- a/nix/zshrc
+++ b/nix/zshrc
@@ -35,10 +35,6 @@ if command -v fzf >/dev/null 2>&1; then
   source <(fzf --zsh)
 fi
 
-if command -v mise >/dev/null 2>&1; then
-  eval "$(mise activate zsh)"
-fi
-
 if command -v starship >/dev/null 2>&1; then
   eval "$(starship init zsh)"
 fi


### PR DESCRIPTION
## Summary

- Replace `mise` in `environment.systemPackages` with `nodejs_24`
- Remove mise shell activation from `nix/zshrc`
- Document Node.js as Nix-managed and add manual cleanup notes for old mise state
- Leave Claude/Codex CLI management to #39

## Validation

- `zsh -n nix/zshrc`
- `darwin-rebuild build --flake .#uranus`
- `nix shell nixpkgs#nodejs_24 -c node --version` -> `v24.15.0`

Closes #38
Part of #37
