### PR TITLE
Manage AI CLIs with Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ $ sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#uranus
 | Area | Location | Notes |
 | --- | --- | --- |
 | CLI packages | `environment.systemPackages` in `nix/darwin.nix` | Command-line tools are installed from nixpkgs. |
+| AI CLIs | `claude-code` and `codex` in `nix/darwin.nix` | Claude Code and Codex CLI are installed from nixpkgs. |
 | Node.js | `nodejs_24` in `nix/darwin.nix` | Node.js is installed from nixpkgs instead of mise. |
 | macOS defaults | `system.defaults` in `nix/darwin.nix` | Dock, Finder, desktop services, and screenshot defaults are managed by nix-darwin. |
 | zsh | `home.file.".zshrc"` in `nix/home.nix` | The zshrc content lives in `nix/zshrc`. |
@@ -84,4 +85,4 @@ After applying the Nix configuration, remove old mise state if it is no longer n
 $ rm -rf ~/.config/mise ~/.local/share/mise
 ```
 
-Claude and Codex CLI installation methods are tracked separately because they were originally installed outside this repository.
+After verifying the Nix-managed Claude Code and Codex CLI installations, remove old manual installs if they are no longer needed.

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -1,5 +1,6 @@
 {
   pkgs,
+  lib,
   username,
   ...
 }:
@@ -11,6 +12,9 @@
   ];
 
   nixpkgs.hostPlatform = "aarch64-darwin";
+  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+    "claude-code"
+  ];
 
   system.primaryUser = username;
   system.stateVersion = 7;
@@ -20,6 +24,8 @@
   programs.zsh.enable = true;
 
   environment.systemPackages = with pkgs; [
+    claude-code
+    codex
     curl
     fzf
     gh


### PR DESCRIPTION
## Summary

- Add `codex` and `claude-code` to the Nix system packages
- Allow the unfree `claude-code` package by name with `allowUnfreePredicate`
- Document that Claude Code and Codex CLI are Nix-managed
- Keep manual install cleanup as a post-apply verification step

## Validation

- `darwin-rebuild build --flake .#uranus`
- `NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#codex nixpkgs#claude-code -c sh -c 'codex --version && claude --version'`
  - `codex-cli 0.133.0`
  - `2.1.148 (Claude Code)`

Closes #39
Part of #37
