### PR TITLE
Document Homebrew cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,21 @@ $ rm -rf ~/.config/mise ~/.local/share/mise
 ```
 
 After verifying the Nix-managed Claude Code and Codex CLI installations, remove old manual installs if they are no longer needed.
+
+Homebrew is no longer on `PATH`, but the previous formulae may still exist under `/opt/homebrew`. Most leaves are now managed by Nix. `go`, `k6`, and `kubectl` are intentionally not migrated because they are not currently needed.
+
+Review the remaining Homebrew leaves before uninstalling them.
+
+```bash
+$ /opt/homebrew/bin/brew leaves
+```
+
+If the list only contains replaced or unused tools, remove the old formulae and their unused dependencies.
+
+```bash
+$ /opt/homebrew/bin/brew uninstall curl fzf gh ghq git gnu-sed gnu-tar go jq k6 libomp mise starship tree uv wget yq
+$ /opt/homebrew/bin/brew autoremove
+$ /opt/homebrew/bin/brew cleanup
+```
+
+Keep Homebrew itself installed until GUI application management is revisited.


### PR DESCRIPTION
## Summary

- Document how to review existing Homebrew leaves after the Nix migration
- Add a cleanup command sequence for replaced or unused Homebrew formulae
- Note that `go`, `k6`, and `kubectl` are intentionally not migrated for now
- Keep Homebrew itself installed until GUI app management is revisited

## Validation

- `darwin-rebuild build --flake .#uranus`

Closes #40
Part of #37
