### PR TITLE
Add uv and ripgrep

### DIFF
--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -12,9 +12,11 @@
   ];
 
   nixpkgs.hostPlatform = "aarch64-darwin";
-  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
-    "claude-code"
-  ];
+  nixpkgs.config.allowUnfreePredicate =
+    pkg:
+    builtins.elem (lib.getName pkg) [
+      "claude-code"
+    ];
 
   system.primaryUser = username;
   system.stateVersion = 7;
@@ -35,8 +37,10 @@
     gnutar
     jq
     nodejs_24
+    ripgrep
     starship
     tree
+    uv
     wget
     yq
   ];


### PR DESCRIPTION
## Summary
- Add uv to the nix-darwin system packages
- Add ripgrep for fast code search
- Apply nixfmt formatting to darwin.nix

## Verification
- nix fmt .
- nix build .#darwinConfigurations.uranus.system
- sudo darwin-rebuild switch --flake .#uranus
- uv --version
- rg --version