### PR TITLE
Add npm supply chain safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ $ sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#uranus
 | macOS defaults | `system.defaults` in `nix/darwin.nix` | Dock, Finder, desktop services, and screenshot defaults are managed by nix-darwin. |
 | zsh | `home.file.".zshrc"` in `nix/home.nix` | The zshrc content lives in `nix/zshrc`. |
 | Git | `programs.git.settings` in `nix/home.nix` | Global Git configuration is managed by Home Manager. |
+| npm | `home.file.".npmrc"` in `nix/home.nix` | npm supply-chain safeguards live in `nix/npmrc`. |
 | SSH | `home.file.".ssh/config"` and `home.activation.createSshDirs` in `nix/home.nix` | SSH config lives in `nix/ssh_config` and uses the 1Password SSH agent. |
 | Docker completion | `docker completion zsh` in `nix/zshrc` | Docker completion is loaded dynamically when the `docker` command is available. |
 

--- a/nix/home.nix
+++ b/nix/home.nix
@@ -27,6 +27,7 @@
 
   home.file.".zshrc".source = ./zshrc;
   home.file.".ssh/config".source = ./ssh_config;
+  home.file.".npmrc".source = ./npmrc;
 
   home.activation.createSshDirs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD mkdir -p "$HOME/.ssh"

--- a/nix/npmrc
+++ b/nix/npmrc
@@ -1,0 +1,2 @@
+min-release-age=3
+ignore-scripts=true


### PR DESCRIPTION
## Summary
- manage ~/.npmrc with Home Manager
- set min-release-age=3 and ignore-scripts=true
- document npm as a managed area

## Verification
- nix flake check